### PR TITLE
UI tweaks for mobile catalog

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -15,7 +15,7 @@ export default function RootLayout({ children }) {
         <link rel="icon" href="/favicon.ico" />
         <meta name="theme-color" content="#8F6A50" />
       </head>
-      <body className="min-h-screen bg-gray-50">
+      <body className="min-h-screen bg-gray-50 text-sm md:text-base lg:text-lg">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- scale base font responsively for legibility
- use `next/image` for catalog items and keep aspect ratio
- add swipeable carousel controls with arrows
- show floating cart button so it is always accessible

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68411479cef8832e964afcfbe5d0bfa4